### PR TITLE
fix(client): MCP execute_command 执行 --help 类命令无输出

### DIFF
--- a/client/core/mcp.go
+++ b/client/core/mcp.go
@@ -1,15 +1,18 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"fmt"
-	"github.com/chainreactors/malice-network/client/repl"
 	"net"
 	"net/http"
 	"strings"
 
+	"github.com/chainreactors/IoM-go/client"
 	"github.com/chainreactors/IoM-go/consts"
 	"github.com/chainreactors/logs"
+	"github.com/chainreactors/malice-network/client/repl"
+	"github.com/kballard/go-shellquote"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -218,6 +221,128 @@ func generateCommandDoc(cmd *cobra.Command) string {
 	return doc.String()
 }
 
+// isHelpRequest reports whether cmdline asks for help, e.g.
+// "bof --help", "elevate EfsPotato -h", "help", "help bof".
+func isHelpRequest(cmdline string) bool {
+	args, err := shellquote.Split(cmdline)
+	if err != nil || len(args) == 0 {
+		return false
+	}
+	if args[0] == "help" {
+		return true
+	}
+	for _, a := range args {
+		if a == "--help" || a == "-h" {
+			return true
+		}
+	}
+	return false
+}
+
+// renderCobraHelp writes a command's help into a buffer and returns the
+// ANSI-stripped text. Cobra normally writes --help to the command output
+// writer (os.Stdout); this captures it so the MCP caller receives the text.
+func renderCobraHelp(cmd *cobra.Command) string {
+	if cmd == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	orig := cmd.OutOrStdout()
+	cmd.SetOut(&buf)
+	err := cmd.Help()
+	cmd.SetOut(orig)
+	if err != nil {
+		return ""
+	}
+	if out := strings.TrimSpace(client.RemoveANSI(buf.String())); out != "" {
+		return out
+	}
+	if doc := strings.TrimSpace(generateCommandDoc(cmd)); doc != "" {
+		return doc
+	}
+	return ""
+}
+
+func menuRoot(con *Console, menu string) *cobra.Command {
+	if con == nil || con.App == nil {
+		return nil
+	}
+	m := con.App.Menu(menu)
+	if m == nil {
+		return nil
+	}
+	return m.Command
+}
+
+func activeMenuRoot(con *Console, roots ...*cobra.Command) *cobra.Command {
+	if con == nil || con.App == nil {
+		return nil
+	}
+	am := con.App.ActiveMenu()
+	if am == nil {
+		return nil
+	}
+	for _, r := range roots {
+		if r != nil && r == am.Command {
+			return r
+		}
+	}
+	return nil
+}
+
+// renderCommandHelp resolves the command targeted by a help request and
+// returns its rendered help text. It tries both menus so implant commands
+// (e.g. "bof") resolve even from the client menu. An empty path ("--help" /
+// "help") returns the active menu's full command tree.
+func (m *MCPServer) renderCommandHelp(cmdline string) string {
+	args, err := shellquote.Split(cmdline)
+	if err != nil {
+		return ""
+	}
+	var path []string
+	for _, a := range args {
+		if a == "--help" || a == "-h" || a == "help" {
+			continue
+		}
+		// MAL/plugin commands use a ":" namespace (e.g. "uac-bypass:elevatedcom")
+		// which maps to a cobra parent->child path. Split on ":" so Find resolves.
+		for _, p := range strings.Split(a, ":") {
+			if p != "" {
+				path = append(path, p)
+			}
+		}
+	}
+
+	implantRoot := menuRoot(m.console, consts.ImplantMenu)
+	clientRoot := menuRoot(m.console, consts.ClientMenu)
+
+	// Serialize against command execution (shared cobra tree / output writer).
+	commandExecMu.Lock()
+	defer commandExecMu.Unlock()
+
+	if len(path) == 0 {
+		root := activeMenuRoot(m.console, implantRoot, clientRoot)
+		if root == nil {
+			root = implantRoot
+		}
+		return renderCobraHelp(root)
+	}
+
+	for _, root := range []*cobra.Command{implantRoot, clientRoot} {
+		if root == nil {
+			continue
+		}
+		target, _, e := root.Find(path)
+		if e != nil || target == nil || target == root {
+			continue
+		}
+		if out := renderCobraHelp(target); out != "" {
+			return out
+		}
+	}
+	return ""
+}
+
 // Start 启动 MCP HTTP 服务器
 func (m *MCPServer) Start(host string, port int) error {
 	addr := fmt.Sprintf("%s:%d", host, port)
@@ -320,6 +445,15 @@ Commands are automatically routed to client menu or implant menu based on whethe
 		}
 
 		sessionID, _ := request.GetArguments()["session_id"].(string)
+
+		// Cobra writes --help to the command output writer (os.Stdout), which
+		// executeCommand does not capture. Short-circuit help requests and
+		// render them into a buffer so the help text reaches the caller.
+		if isHelpRequest(command) {
+			if help := m.renderCommandHelp(command); help != "" {
+				return mcp.NewToolResultText(help), nil
+			}
+		}
 
 		response, err := executeCommand(m.console, command, sessionID, consts.CalleeMCP)
 		if err != nil {


### PR DESCRIPTION
## Summary

修复通过 MCP 调用 `execute_command("bof --help")`（以及任何 `--help` / `-h` / `help` 形态）始终返回
`Command executed successfully (no output)` 的问题。终端中直接执行 `--help` 有完整输出。

## Root Cause

两个原因（均在 `client/core/`）：

1. **`execute_command` 捕获不到 Cobra 的 help 文本**
   - `execute_command` → `executeCommandWithTaskWait`（`utils.go:204`）用 `client.Stdout.Range(start, now)` 截取输出。
   - `client.Stdout` 是 `NewStdoutWrapper(os.Stdout)` 环形缓冲 wrapper（`external/IoM-go/client/log.go:16`），只有写入该 wrapper 的内容才能被 `.Range()` 截到。
   - Cobra 的 `--help` 走 `cmd.OutOrStdout()`，全仓库没有任何 `cmd.SetOut(client.Stdout)`，help 直接打到原始 `os.Stdout`，绕过 wrapper → `.Range()` 截到空串 → MCP 返回 "no output"。
   - 对照：`module list` / `whoami` 走 console 日志路径（`logs.Log.SetOutput(client.Stdout)`，`console.go:247`），所以能被截到。

2. **MCP server 的误导性 Tip**
   - `mcp.go:448` 在每次 `search_commands` 返回末尾硬编码
     `Tip: Use execute_command("<command> --help") for detailed usage.`，
     即 MCP 主动指引 AI 使用一条必然返回空的路径。

## Fix

在 `execute_command` handler 中**短路 help 请求**：识别 `--help` / `-h` / `help`，
用 `cmd.SetOut(&buf)` + `cmd.Help()` 将 help 文本渲染进缓冲后返回，绕开 stdout 捕获通道。

**唯一改动文件：`client/core/mcp.go`**（+135 / −1，其中 −1 为 `repl` import 的 goimports 位置调整）：

| 改动 | 内容 |
|---|---|
| imports | 新增 `bytes`、`github.com/chainreactors/IoM-go/client`（`RemoveANSI`）、`github.com/kballard/go-shellquote` |
| 新增 5 个函数 | `isHelpRequest`（识别 help 请求）、`renderCobraHelp`（缓冲捕获 help 并去 ANSI，空则 fallback 到既有 `generateCommandDoc`）、`menuRoot`、`activeMenuRoot`、`renderCommandHelp`（跨 implant/client 两个菜单解析目标命令；支持 MAL 插件 `:` 命名空间拆分；与命令执行共享 `commandExecMu` 串行化） |
| handler 短路 | `registerExecuteCommandTool` 中 `isHelpRequest` 命中且渲染成功时直接返回 help 文本 |

解析失败（help 为空）时自然落回原 `executeCommand` 路径，**对非 help 命令零影响**。

## Test Plan

- [ ] MCP 调用 `execute_command("bof --help")` 返回完整 help 文本
- [ ] `execute_command("help")` 返回当前活动菜单的命令树
- [ ] MAL 插件命令（如 `uac-bypass:elevatedcom --help`）可正常解析
- [ ] 非 help 命令（`whoami`、`module list` 等）行为与改动前一致
